### PR TITLE
Improvements for CloudWatch logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@ Intial commit prior to public release.
 
 ## [1.0.0] - Initial release
 
-
+## [1.0.1] - API Gateway logging fix
+Fix for issue with deployment when users try to deploy in an AWS account that has not been configured for API Gateway logging.
 

--- a/deployment/contact-surveys-amazon-connect.yaml
+++ b/deployment/contact-surveys-amazon-connect.yaml
@@ -732,6 +732,27 @@ Resources:
             RestApiId: !Ref SurveysApiGateway
             Type: COGNITO_USER_POOLS
 
+    ApiGatewayLoggingRole:
+        Type: AWS::IAM::Role
+        Properties:
+            AssumeRolePolicyDocument:
+                Version: "2012-10-17"
+                Statement:
+                    - Effect: Allow
+                      Principal:
+                          Service: apigateway.amazonaws.com
+                      Action: sts:AssumeRole
+            ManagedPolicyArns:
+                - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+
+    ApiGatewayLoggingRoleSetup:
+        Type: AWS::ApiGateway::Account
+        DependsOn: 
+            - SurveysApiGateway
+            - ApiGatewayLoggingRole
+        Properties: 
+          CloudWatchRoleArn: !GetAtt ApiGatewayLoggingRole.Arn
+
     SurveysApiGateway:
         Type: AWS::ApiGateway::RestApi
         Properties:
@@ -752,6 +773,7 @@ Resources:
         Type: AWS::ApiGateway::Stage
         DependsOn:
             - SurveysApiGateway
+            - ApiGatewayLoggingRoleSetup
         Properties:
             RestApiId: !Ref SurveysApiGateway
             StageName: dev

--- a/deployment/contact-surveys-amazon-connect.yaml
+++ b/deployment/contact-surveys-amazon-connect.yaml
@@ -17,6 +17,24 @@ Parameters:
     AdminEmailAddress:
         Type: String
         Description: "The email address for the initial user of the solution"
+    CreateAPILevelCloudWatchRole:
+        Type: String
+        Description: "The email address for the initial user of the solution"
+        Default: "TRUE"
+        AllowedValues:
+            - "TRUE"
+            - "FALSE"
+
+#################
+### CONDITIONS ##
+#################
+
+Conditions:
+
+    deployAccountLevelAPICloudWatchRole: !Equals
+        - !Ref CreateAPILevelCloudWatchRole
+        - "TRUE"
+
 
 Resources:
     UserPool:
@@ -783,6 +801,29 @@ Resources:
                   HttpMethod: "*"
                   LoggingLevel: "ERROR"
                   ResourcePath: "/*"
+
+# Add CloudWatch Logging Role to the API Gateway Settings for the account.
+    ApiCWLRoleArn:
+        Type: AWS::ApiGateway::Account
+        Condition: deployAccountLevelAPICloudWatchRole
+        Properties: 
+            CloudWatchRoleArn: !GetAtt APIGatewayCloudWatchRole.Arn
+
+# IAM Role for API Gateway + CloudWatch Logging
+    APIGatewayCloudWatchRole:
+        Type: AWS::IAM::Role
+        Condition: deployAccountLevelAPICloudWatchRole
+        Properties:
+            AssumeRolePolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                    Action: 'sts:AssumeRole'
+                    Effect: Allow
+                    Principal:
+                        Service: apigateway.amazonaws.com
+            Path: /
+            ManagedPolicyArns:
+            - 'arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs'
 
     ApiResultsOptionsMethod:
         Type: AWS::ApiGateway::Method


### PR DESCRIPTION
*Issue #, if available:*

API Stage build was failing due no AWS CloudWatch logging role being attached to the API gateway.

*Description of changes:*

- Created condition for the user to select if they want to deploy the Role or not.
- Added API CloudWatch Role
- Joined API CloudWatch Role to the API Gateway

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
